### PR TITLE
Fix map view on sidebar toggle

### DIFF
--- a/js/batData.js
+++ b/js/batData.js
@@ -549,13 +549,11 @@ export async function initBatDataLayer(map, layersControl) {
   const panel = document.getElementById("bat-filter-panel");
   const toggleBar = document.getElementById("filter-toggle-bar");
   const arrowIcon = document.getElementById("filterToggleArrow");
-  const hongKongBounds = [
-    [22.15, 113.825],
-    [22.55, 114.4],
-  ];
   function resizeAndFit() {
+    // Only recalculate the map size without altering the current
+    // center/zoom so the view stays the same when the sidebar
+    // collapses or expands.
     map.invalidateSize();
-    map.fitBounds(hongKongBounds);
   }
   
   if (window.innerWidth < 1023) {


### PR DESCRIPTION
## Summary
- prevent map from resetting when collapsing or expanding the filter panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888e8a30008832a99a93dc5fc015d49