### PR TITLE
Adjust sidebar dropdown display

### DIFF
--- a/css/filter-panel.css
+++ b/css/filter-panel.css
@@ -26,7 +26,7 @@
   width: 300px;
   max-width: 300px;
   opacity: 1;
-  overflow: hidden;
+  overflow: visible;
   transition: max-width 0.3s ease, opacity 0.3s ease;
 }
 
@@ -101,7 +101,7 @@
 .filter-content {
   padding: 12px;
   flex: 1;
-  overflow-y: auto;
+  overflow: visible;
 }
 
 .form-row {
@@ -276,6 +276,7 @@ select:hover {
   padding: 4px 8px;
   cursor: pointer;
   font-size:12px;
+  white-space: nowrap;
 }
 
 .sidebar-combo .combo-options li:hover {


### PR DESCRIPTION
## Summary
- allow sidebar dropdown overflow without scrollbars
- ensure dropdown options stay on one line

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688970e6ef28832abfce6682bae6eef2