### PR TITLE
Fix sidebar filter defaults

### DIFF
--- a/Map2.html
+++ b/Map2.html
@@ -27,7 +27,7 @@
           <h3>All Bat Data Filter</h3>
           <div class="form-row">
             <label for="displayMode">Display Mode:</label>
-            <select id="displayMode" class="form-control">
+            <select id="displayMode" class="sidebar-combo">
               <option value="point">Point Mode</option>
               <option value="grid">Grid Mode</option>
             </select>
@@ -44,63 +44,63 @@
           
           <div class="form-row">
             <label for="filterLocation">Location:</label>
-            <select id="filterLocation" class="form-control">
+            <select id="filterLocation" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterHabitat">Habitat:</label>
-            <select id="filterHabitat" class="form-control">
+            <select id="filterHabitat" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterDataSource">Data Source:</label>
-            <select id="filterDataSource" class="form-control">
+            <select id="filterDataSource" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterRecorders">Recorders:</label>
-            <select id="filterRecorders" class="form-control">
+            <select id="filterRecorders" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterFamily">Family:</label>
-            <select id="filterFamily" class="form-control">
+            <select id="filterFamily" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterGenus">Genus:</label>
-            <select id="filterGenus" class="form-control">
+            <select id="filterGenus" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterSpecies">Scientific name:</label>
-            <select id="filterSpecies" class="form-control">
+            <select id="filterSpecies" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterCommonEng">English Name:</label>
-            <select id="filterCommonEng" class="form-control">
+            <select id="filterCommonEng" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>
 
           <div class="form-row">
             <label for="filterCommonChi">Chinese Name:</label>
-            <select id="filterCommonChi" class="form-control">
+            <select id="filterCommonChi" class="sidebar-combo">
               <option value="">All</option>
             </select>
           </div>

--- a/js/sidebarCombo.js
+++ b/js/sidebarCombo.js
@@ -4,6 +4,8 @@ export function setupSidebarCombos(container = document) {
 }
 
 function replaceSelectWithCombo(select) {
+  // clear any default selection so button shows "Select"
+  select.selectedIndex = -1;
   const combo = document.createElement('div');
   combo.className = 'sidebar-combo';
 
@@ -62,16 +64,33 @@ function replaceSelectWithCombo(select) {
   list.addEventListener('click', (e) => {
     const li = e.target.closest('li');
     if (!li) return;
-    li.classList.toggle('selected');
-    const option = select.querySelector(`option[value="${CSS.escape(li.dataset.value)}"]`);
-    if (li.classList.contains('selected')) {
-      option.selected = true;
+    const value = li.dataset.value;
+    const option = select.querySelector(`option[value="${CSS.escape(value)}"]`);
+    const allLi = list.querySelector('li[data-value=""]');
+    const allOption = select.querySelector('option[value=""]');
+
+    if (value === '') {
+      list.querySelectorAll('li').forEach((other) => {
+        if (other !== li) {
+          other.classList.remove('selected');
+          const opt = select.querySelector(`option[value="${CSS.escape(other.dataset.value)}"]`);
+          if (opt) opt.selected = false;
+        }
+      });
+      li.classList.add('selected');
+      if (allOption) allOption.selected = true;
     } else {
-      option.selected = false;
+      if (allLi) allLi.classList.remove('selected');
+      if (allOption) allOption.selected = false;
+
+      li.classList.toggle('selected');
+      option.selected = li.classList.contains('selected');
     }
     updateToggleText();
     select.dispatchEvent(new Event('change'));
   });
+
+  select.addEventListener('change', updateToggleText);
 
   function updateToggleText() {
     const selected = list.querySelectorAll('li.selected .combo-label');


### PR DESCRIPTION
## Summary
- clear default selection when turning selects into comboboxes
- deselect `All` when other options are chosen
- update filters to use `sidebar-combo` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68897b1f344c832a9c6c6f5cec092644