### PR TITLE
Improve sidebar filter defaults

### DIFF
--- a/Map2.html
+++ b/Map2.html
@@ -27,8 +27,8 @@
           <h3>All Bat Data Filter</h3>
           <div class="form-row">
             <label for="displayMode">Display Mode:</label>
-            <select id="displayMode" class="sidebar-combo">
-              <option value="point">Point Mode</option>
+            <select id="displayMode" class="sidebar-combo" data-preserve-default data-single>
+              <option value="point" selected>Point Mode</option>
               <option value="grid">Grid Mode</option>
             </select>
           </div>          
@@ -58,7 +58,7 @@
 
           <div class="form-row">
             <label for="filterDataSource">Data Source:</label>
-            <select id="filterDataSource" class="sidebar-combo">
+            <select id="filterDataSource" class="sidebar-combo" data-preserve-default>
               <option value="">All</option>
             </select>
           </div>

--- a/css/filter-panel.css
+++ b/css/filter-panel.css
@@ -306,3 +306,7 @@ select:hover {
   font-weight: bold;
 }
 
+.sidebar-combo .scientific-label {
+  font-style: italic;
+}
+

--- a/js/batData.js
+++ b/js/batData.js
@@ -53,8 +53,15 @@ export async function initBatDataLayer(map, layersControl) {
         const opt = document.createElement("option");
         opt.value = val;
         opt.textContent = val;
+        if ((key === "Genus" || key === "Species") && !["sp.", "sp.1", "sp.2", "sp.3", "Unknown", "All"].includes(val)) {
+          opt.style.fontStyle = "italic";
+        }
         select.appendChild(opt);
       });
+
+      if (key === "DataSource") {
+        select.value = "Hong Kong Bat Acoustic Project";
+      }
 
       // === ComboBox enhancement ===
       select.addEventListener("input", e => {

--- a/js/sidebarCombo.js
+++ b/js/sidebarCombo.js
@@ -4,8 +4,15 @@ export function setupSidebarCombos(container = document) {
 }
 
 function replaceSelectWithCombo(select) {
-  // clear any default selection so button shows "Select"
-  select.selectedIndex = -1;
+  const isSingle = select.hasAttribute('data-single');
+  const preserve = select.hasAttribute('data-preserve-default');
+  const isScientific = select.id === 'filterGenus' || select.id === 'filterSpecies';
+  const NO_ITALIC = ['sp.', 'sp.1', 'sp.2', 'sp.3', 'Unknown', 'All'];
+
+  if (!preserve) {
+    // clear any default selection so button shows "Select"
+    select.selectedIndex = -1;
+  }
   const combo = document.createElement('div');
   combo.className = 'sidebar-combo';
 
@@ -22,6 +29,9 @@ function replaceSelectWithCombo(select) {
   searchInput.type = 'text';
   searchInput.className = 'combo-search';
   searchInput.placeholder = 'Search...';
+  if (isSingle) {
+    searchInput.style.display = 'none';
+  }
   dropdown.appendChild(searchInput);
 
   const list = document.createElement('ul');
@@ -30,7 +40,10 @@ function replaceSelectWithCombo(select) {
   Array.from(select.options).forEach((opt) => {
     const li = document.createElement('li');
     li.dataset.value = opt.value;
-    li.innerHTML = `<i data-lucide="check" class="combo-check"></i><span class="combo-label">${opt.textContent}</span>`;
+    const text = opt.textContent;
+    const italic = isScientific && !NO_ITALIC.includes(text);
+    if (italic) opt.style.fontStyle = 'italic';
+    li.innerHTML = `<i data-lucide="check" class="combo-check"></i><span class="combo-label${italic ? ' scientific-label' : ''}">${text}</span>`;
     if (opt.selected) {
       li.classList.add('selected');
     }
@@ -54,12 +67,14 @@ function replaceSelectWithCombo(select) {
     }
   });
 
-  searchInput.addEventListener('input', () => {
-    const term = searchInput.value.toLowerCase();
-    list.querySelectorAll('li').forEach((li) => {
-      li.style.display = li.textContent.toLowerCase().includes(term) ? '' : 'none';
+  if (!isSingle) {
+    searchInput.addEventListener('input', () => {
+      const term = searchInput.value.toLowerCase();
+      list.querySelectorAll('li').forEach((li) => {
+        li.style.display = li.textContent.toLowerCase().includes(term) ? '' : 'none';
+      });
     });
-  });
+  }
 
   list.addEventListener('click', (e) => {
     const li = e.target.closest('li');
@@ -69,7 +84,16 @@ function replaceSelectWithCombo(select) {
     const allLi = list.querySelector('li[data-value=""]');
     const allOption = select.querySelector('option[value=""]');
 
-    if (value === '') {
+    if (isSingle) {
+      list.querySelectorAll('li').forEach((other) => {
+        other.classList.remove('selected');
+        const opt = select.querySelector(`option[value="${CSS.escape(other.dataset.value)}"]`);
+        if (opt) opt.selected = false;
+      });
+      li.classList.add('selected');
+      option.selected = true;
+      combo.classList.remove('open');
+    } else if (value === '') {
       list.querySelectorAll('li').forEach((other) => {
         if (other !== li) {
           other.classList.remove('selected');


### PR DESCRIPTION
## Summary
- preserve default selections for specific sidebar combos
- allow single-select mode and hide search for display mode
- style genus and species options in italics
- default display mode to Point and default data source to Hong Kong Bat Acoustic Project

## Testing
- `node --check js/sidebarCombo.js`
- `node --check js/batData.js`


------
https://chatgpt.com/codex/tasks/task_e_688980010514832a9704665a7add7da5