### PR TITLE
Adjust italic styling for species names

### DIFF
--- a/css/filter-panel.css
+++ b/css/filter-panel.css
@@ -311,3 +311,7 @@ select:hover {
   font-style: italic;
 }
 
+.sidebar-combo .scientific-label .no-italic {
+  font-style: normal;
+}
+

--- a/js/batData.js
+++ b/js/batData.js
@@ -3,6 +3,7 @@ const tooltipElements = [];
 const manualMoved = [];
 const hoverTooltip = document.getElementById("hoverTooltip");
 import { makeTooltipDraggable } from './draggableTooltip.js';
+const NO_ITALIC = ["sp.", "sp.1", "sp.2", "sp.3", "Unknown", "All", "NA"];
 
 export async function initBatDataLayer(map, layersControl) {
   const response = await fetch('https://opensheet.elk.sh/1Al_sWwiIU6DtQv6sMFvXb9wBUbBiE-zcYk8vEwV82x8/sheet2');
@@ -53,7 +54,7 @@ export async function initBatDataLayer(map, layersControl) {
         const opt = document.createElement("option");
         opt.value = val;
         opt.textContent = val;
-        if ((key === "Genus" || key === "Species") && !["sp.", "sp.1", "sp.2", "sp.3", "Unknown", "All"].includes(val)) {
+        if ((key === "Genus" || key === "Species") && !NO_ITALIC.some(token => val.includes(token))) {
           opt.style.fontStyle = "italic";
         }
         select.appendChild(opt);
@@ -79,6 +80,9 @@ export async function initBatDataLayer(map, layersControl) {
           const opt = document.createElement("option");
           opt.value = val;
           opt.textContent = val;
+          if ((key === "Genus" || key === "Species") && !NO_ITALIC.some(token => val.includes(token))) {
+            opt.style.fontStyle = "italic";
+          }
           select.appendChild(opt);
         });
         select.value = currentValue;
@@ -199,6 +203,9 @@ export async function initBatDataLayer(map, layersControl) {
         const opt = document.createElement("option");
         opt.value = val;
         opt.textContent = val;
+        if ((selectEl.id === "filterGenus" || selectEl.id === "filterSpecies") && !NO_ITALIC.some(token => val.includes(token))) {
+          opt.style.fontStyle = "italic";
+        }
         selectEl.appendChild(opt);
       });
       selectEl.value = "";
@@ -530,6 +537,9 @@ export async function initBatDataLayer(map, layersControl) {
           const opt = document.createElement("option");
           opt.value = val;
           opt.textContent = val;
+          if ((key === "Genus" || key === "Species") && !NO_ITALIC.some(token => val.includes(token))) {
+            opt.style.fontStyle = "italic";
+          }
           select.appendChild(opt);
         });
 

--- a/js/sidebarCombo.js
+++ b/js/sidebarCombo.js
@@ -7,7 +7,17 @@ function replaceSelectWithCombo(select) {
   const isSingle = select.hasAttribute('data-single');
   const preserve = select.hasAttribute('data-preserve-default');
   const isScientific = select.id === 'filterGenus' || select.id === 'filterSpecies';
-  const NO_ITALIC = ['sp.', 'sp.1', 'sp.2', 'sp.3', 'Unknown', 'All'];
+  const NO_ITALIC = ['sp.', 'sp.1', 'sp.2', 'sp.3', 'Unknown', 'All', 'NA'];
+
+  const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const formatScientificText = (text) => {
+    let formatted = text;
+    NO_ITALIC.forEach((token) => {
+      const regex = new RegExp(escapeRegExp(token), 'g');
+      formatted = formatted.replace(regex, `<span class="no-italic">${token}</span>`);
+    });
+    return formatted;
+  };
 
   if (!preserve) {
     // clear any default selection so button shows "Select"
@@ -41,9 +51,12 @@ function replaceSelectWithCombo(select) {
     const li = document.createElement('li');
     li.dataset.value = opt.value;
     const text = opt.textContent;
-    const italic = isScientific && !NO_ITALIC.includes(text);
+    const italic = isScientific && !NO_ITALIC.some((token) => text.includes(token));
     if (italic) opt.style.fontStyle = 'italic';
-    li.innerHTML = `<i data-lucide="check" class="combo-check"></i><span class="combo-label${italic ? ' scientific-label' : ''}">${text}</span>`;
+    const labelHtml = isScientific
+      ? `<span class="combo-label scientific-label">${formatScientificText(text)}</span>`
+      : `<span class="combo-label">${text}</span>`;
+    li.innerHTML = `<i data-lucide="check" class="combo-check"></i>${labelHtml}`;
     if (opt.selected) {
       li.classList.add('selected');
     }


### PR DESCRIPTION
## Summary
- handle partial matches when italicizing scientific names
- ensure NA is treated as non-italic
- support nested styling in sidebar combo UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68898466cf0c832abd846e7d888e6fb9