### PR TITLE
Connect tooltips to map features

### DIFF
--- a/Map2.html
+++ b/Map2.html
@@ -138,6 +138,7 @@
           <button id="goBtn">Go</button>
         </div>
         <div id="hoverTooltip" class="hover-tooltip"></div>
+        <svg id="tooltipLines"></svg>
       </div>
     </div>
 

--- a/css/global.css
+++ b/css/global.css
@@ -16,6 +16,20 @@ html, body {
   transition: margin-left 0.3s ease, width 0.3s ease;
 }
 
+#tooltipLines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.tooltip-line {
+  stroke: #555;
+  stroke-width: 2;
+}
+
 #map-container.collapsed #map {
   margin-left: 0;
 }

--- a/js/batData.js
+++ b/js/batData.js
@@ -1,8 +1,10 @@
 const lockedLayers = [];
 const tooltipElements = [];
 const manualMoved = [];
+const tooltipLines = [];
 const hoverTooltip = document.getElementById("hoverTooltip");
 import { makeTooltipDraggable } from './draggableTooltip.js';
+import { attachTooltipLine } from './tooltipLine.js';
 
 export async function initBatDataLayer(map, layersControl) {
   const response = await fetch('https://opensheet.elk.sh/1Al_sWwiIU6DtQv6sMFvXb9wBUbBiE-zcYk8vEwV82x8/sheet2');
@@ -13,6 +15,10 @@ export async function initBatDataLayer(map, layersControl) {
 
   let batLayer = null;
   let gridLayer = null;
+
+  map.on('move zoom', () => {
+    tooltipLines.forEach((l) => l.update());
+  });
   
   const fieldMap = {
     Location: "Location",
@@ -127,13 +133,17 @@ export async function initBatDataLayer(map, layersControl) {
   lockedLayers.push(layer);
   tooltipElements.push(tooltip);
   manualMoved.push(false);
+  const lineObj = attachTooltipLine(map,
+    () => (layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter()),
+    tooltip);
+  tooltipLines.push(lineObj);
 
   const center = map.latLngToContainerPoint(
     layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter()
   );
   positionTooltip(tooltip, center);
 
-  makeTooltipDraggable(tooltip);
+  makeTooltipDraggable(tooltip, { onDrag: () => lineObj.update() });
 
   const closeBtn = tooltip.querySelector(".tooltip-close");
   if (closeBtn) {
@@ -170,6 +180,10 @@ export async function initBatDataLayer(map, layersControl) {
       tooltipElements[idx].remove();
       tooltipElements.splice(idx, 1);
       manualMoved.splice(idx, 1);
+      if (tooltipLines[idx]) {
+        tooltipLines[idx].remove();
+        tooltipLines.splice(idx, 1);
+      }
     }
   }
 

--- a/js/batGrid.js
+++ b/js/batGrid.js
@@ -1,4 +1,5 @@
 import { makeTooltipDraggable } from './draggableTooltip.js';
+import { attachTooltipLine } from './tooltipLine.js';
 
 export function initBatGrid(map, layersControl) {
   const gridLayer = L.geoJSON(null);
@@ -9,6 +10,11 @@ export function initBatGrid(map, layersControl) {
   const lockedLayers = [];
   const tooltipElements = [];
   const manualMoved = [];
+  const tooltipLines = [];
+
+  map.on('move zoom', () => {
+    tooltipLines.forEach((l) => l.update());
+  });
 
   const legend = L.control({ position: "bottomright" });
   legend.onAdd = function () {
@@ -136,11 +142,13 @@ export function initBatGrid(map, layersControl) {
     lockedLayers.push(layer);
     tooltipElements.push(tooltip);
     manualMoved.push(false);
+    const lineObj = attachTooltipLine(map, () => layer.getBounds().getCenter(), tooltip);
+    tooltipLines.push(lineObj);
 
     const center = map.latLngToContainerPoint(layer.getBounds().getCenter());
     positionTooltip(tooltip, center);
 
-    makeTooltipDraggable(tooltip);
+    makeTooltipDraggable(tooltip, { onDrag: () => lineObj.update() });
   }
 
   function closeLockTooltip(event, closeButton) {
@@ -158,8 +166,12 @@ export function initBatGrid(map, layersControl) {
       tooltipElements[idx].remove();
       tooltipElements.splice(idx, 1);
       manualMoved.splice(idx, 1);
+      if (tooltipLines[idx]) {
+        tooltipLines[idx].remove();
+        tooltipLines.splice(idx, 1);
+      }
     }
-  }  
+  }
 
   function positionTooltip(domElement, point) {
     const mapSize = map.getSize();

--- a/js/draggableTooltip.js
+++ b/js/draggableTooltip.js
@@ -1,4 +1,5 @@
-export function makeTooltipDraggable(tooltip, onDragEnd = null) {
+export function makeTooltipDraggable(tooltip, options = {}) {
+  const { onDragEnd = null, onDrag = null } = options;
   let isDragging = false;
   let offsetX, offsetY;
 
@@ -38,6 +39,7 @@ export function makeTooltipDraggable(tooltip, onDragEnd = null) {
 
     tooltip.style.left = `${clientX - offsetX}px`;
     tooltip.style.top = `${clientY - offsetY}px`;
+    if (typeof onDrag === 'function') onDrag();
   }
 
   function endDrag() {

--- a/js/drawPoints.js
+++ b/js/drawPoints.js
@@ -1,7 +1,11 @@
+import { attachTooltipLine } from './tooltipLine.js';
+import { makeTooltipDraggable } from './draggableTooltip.js';
+
 export function initDrawPoint(map, crsModeSelect) {
   let drawMode = false;
   const drawnPoints = [];
   const drawnTooltips = {};
+  const drawnLines = {};
 
   const drawPointBtn = document.getElementById("drawPointBtn");
 
@@ -68,6 +72,9 @@ export function initDrawPoint(map, crsModeSelect) {
         <div class="tooltip-content">${content}</div>
       </div>`;
     document.getElementById("map").appendChild(tooltip);
+    const lineObj = attachTooltipLine(map, () => marker.getLatLng(), tooltip);
+    drawnLines[markerId] = lineObj;
+    makeTooltipDraggable(tooltip, { onDrag: () => lineObj.update() });
     return tooltip;
   }
 
@@ -109,6 +116,8 @@ export function initDrawPoint(map, crsModeSelect) {
 
     tooltip.style.left = `${left}px`;
     tooltip.style.top = `${top}px`;
+    const lineObj = drawnLines[id];
+    if (lineObj) lineObj.update();
   }
 
   map.on("move zoom", () => {
@@ -122,6 +131,10 @@ export function initDrawPoint(map, crsModeSelect) {
     if (idx !== -1) {
       map.removeLayer(drawnPoints[idx]);
       if (drawnTooltips[markerId]) drawnTooltips[markerId].remove();
+      if (drawnLines[markerId]) {
+        drawnLines[markerId].remove();
+        delete drawnLines[markerId];
+      }
       drawnPoints.splice(idx, 1);
       delete drawnTooltips[markerId];
     }

--- a/js/goto.js
+++ b/js/goto.js
@@ -1,3 +1,6 @@
+import { makeTooltipDraggable } from './draggableTooltip.js';
+import { attachTooltipLine } from './tooltipLine.js';
+
 export function initGotoPanel(map) {
   const panel = document.getElementById("gotoPanel");
   const toggleBtn = document.getElementById("gotoToggleBtn");
@@ -5,6 +8,7 @@ export function initGotoPanel(map) {
   const clearBtn = document.getElementById("clearBtn");
   const gotoTooltips = {};
   const gotoMarkers = [];
+  const gotoLines = {};
 
   // ✅ 防止干擾地圖操作
   L.DomEvent.disableClickPropagation(panel);
@@ -65,6 +69,10 @@ export function initGotoPanel(map) {
         if (existing) {
           existing.remove();
           delete gotoTooltips[markerId];
+          if (gotoLines[markerId]) {
+            gotoLines[markerId].remove();
+            delete gotoLines[markerId];
+          }
         } else {
           updateGotoMarkerPopup(marker); // ✅ 加這行確保是最新座標
           const newContent = currentTooltipContent(marker);
@@ -98,6 +106,10 @@ export function initGotoPanel(map) {
       if (gotoTooltips[id]) {
         gotoTooltips[id].remove();
         delete gotoTooltips[id];
+      }
+      if (gotoLines[id]) {
+        gotoLines[id].remove();
+        delete gotoLines[id];
       }
     });
     gotoMarkers.length = 0;
@@ -172,6 +184,9 @@ function createPointTooltip(marker, content) {
       <div class="tooltip-content">${content}</div>
     </div>`;
   document.getElementById("map").appendChild(tooltip);
+  const lineObj = attachTooltipLine(map, () => marker.getLatLng(), tooltip);
+  gotoLines[L.stamp(marker)] = lineObj;
+  makeTooltipDraggable(tooltip, { onDrag: () => lineObj.update() });
   return tooltip;
 }
 
@@ -209,6 +224,8 @@ function moveGotoTooltip(marker) {
   if (top < 0) top = 10;
   tooltip.style.left = `${left}px`;
   tooltip.style.top = `${top}px`;
+  const line = gotoLines[L.stamp(marker)];
+  if (line) line.update();
 }
 
 window.deleteGotoMarker = function (event, markerId) {
@@ -219,8 +236,12 @@ window.deleteGotoMarker = function (event, markerId) {
     if (gotoTooltips[markerId]) gotoTooltips[markerId].remove();
     gotoMarkers.splice(idx, 1);
     delete gotoTooltips[markerId];
+    if (gotoLines[markerId]) {
+      gotoLines[markerId].remove();
+      delete gotoLines[markerId];
+    }
   }
-};  
+};
 
 function currentTooltipContent(marker) {
   const latlng = marker.getLatLng();

--- a/js/initMap.js
+++ b/js/initMap.js
@@ -93,6 +93,23 @@ export async function initMap() {
 
   const layersControl = L.control.layers(baseMaps, {}, { collapsed: true }).addTo(map);
 
+  let baseLayerCategory = 'street';
+  map.getBaseLayerCategory = () => baseLayerCategory;
+
+  function updateLineColors() {
+    const lines = document.querySelectorAll('#tooltipLines .tooltip-line');
+    const color = baseLayerCategory === 'satellite' ? '#fff' : '#555';
+    lines.forEach((line) => line.setAttribute('stroke', color));
+  }
+
+  map.on('baselayerchange', (e) => {
+    const name = e.name.toLowerCase();
+    baseLayerCategory = name.includes('satellite') || name.includes('hybrid') ? 'satellite' : 'street';
+    updateLineColors();
+  });
+
+  updateLineColors();
+
   fetch("https://raw.githubusercontent.com/PanTong55/hkgrid/main/OSM_CP.geojson")
     .then((r) => r.json())
     .then((hkcpData) => {

--- a/js/tooltipLine.js
+++ b/js/tooltipLine.js
@@ -1,0 +1,37 @@
+export function attachTooltipLine(map, getLatLng, tooltip) {
+  const svg = document.getElementById('tooltipLines');
+  if (!svg) return null;
+  const ns = 'http://www.w3.org/2000/svg';
+  const line = document.createElementNS(ns, 'line');
+  line.classList.add('tooltip-line');
+  svg.appendChild(line);
+
+  function getColor() {
+    return map.getBaseLayerCategory && map.getBaseLayerCategory() === 'satellite' ? '#fff' : '#555';
+  }
+
+  function update() {
+    const latlng = typeof getLatLng === 'function' ? getLatLng() : getLatLng;
+    const point = map.latLngToContainerPoint(latlng);
+    const svgRect = svg.getBoundingClientRect();
+    const ttRect = tooltip.getBoundingClientRect();
+    const x1 = point.x;
+    const y1 = point.y;
+    const x2 = ttRect.left + ttRect.width / 2 - svgRect.left;
+    const y2 = ttRect.top + ttRect.height / 2 - svgRect.top;
+    line.setAttribute('x1', x1);
+    line.setAttribute('y1', y1);
+    line.setAttribute('x2', x2);
+    line.setAttribute('y2', y2);
+    line.setAttribute('stroke', getColor());
+    line.setAttribute('stroke-width', 2);
+  }
+
+  update();
+
+  return {
+    line,
+    update,
+    remove() { line.remove(); }
+  };
+}


### PR DESCRIPTION
## Summary
- draw an SVG line from floating tooltips to their map feature
- colour tooltip lines based on basemap type
- update tooltip lines when dragging, moving or deleting tooltips
- make tooltip lines work for grid, bat data, drawn points and goto points

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889ae0a7a14832a94c28ed7702a9fd1