### PR TITLE
Add tooltip line connector synced with basemap

### DIFF
--- a/Map2.html
+++ b/Map2.html
@@ -138,6 +138,7 @@
           <button id="goBtn">Go</button>
         </div>
         <div id="hoverTooltip" class="hover-tooltip"></div>
+        <svg id="tooltip-lines"></svg>
       </div>
     </div>
 
@@ -148,6 +149,7 @@
     <script type="module">
       import { initMap } from "./js/initMap.js";
       const { map, layersControl } = await initMap();
+      import("./js/tooltipLine.js").then((m) => m.initTooltipLine(map));
 
       const crsModeSelect = document.getElementById("crsMode");
       const coordDisplay = document.getElementById("mouseCoords");

--- a/css/global.css
+++ b/css/global.css
@@ -477,3 +477,19 @@ a.tooltip-close:hover {
     box-shadow: 0 0 0 0 rgba(0, 122, 255, 0);
   }
 }
+
+/* Tooltip connector lines */
+#tooltip-lines {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 998;
+}
+
+.tooltip-line {
+  stroke-width: 2;
+  pointer-events: none;
+}

--- a/js/batData.js
+++ b/js/batData.js
@@ -3,6 +3,7 @@ const tooltipElements = [];
 const manualMoved = [];
 const hoverTooltip = document.getElementById("hoverTooltip");
 import { makeTooltipDraggable } from './draggableTooltip.js';
+import { attachTooltipLine, detachTooltipLine, updateTooltipLine } from './tooltipLine.js';
 
 export async function initBatDataLayer(map, layersControl) {
   const response = await fetch('https://opensheet.elk.sh/1Al_sWwiIU6DtQv6sMFvXb9wBUbBiE-zcYk8vEwV82x8/sheet2');
@@ -128,12 +129,15 @@ export async function initBatDataLayer(map, layersControl) {
   tooltipElements.push(tooltip);
   manualMoved.push(false);
 
-  const center = map.latLngToContainerPoint(
-    layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter()
-  );
+  const targetLatLng = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
+  const center = map.latLngToContainerPoint(targetLatLng);
   positionTooltip(tooltip, center);
 
-  makeTooltipDraggable(tooltip);
+  makeTooltipDraggable(tooltip, {
+    onDrag: () => updateTooltipLine(tooltip),
+    onDragEnd: () => updateTooltipLine(tooltip)
+  });
+  attachTooltipLine(tooltip, targetLatLng);
 
   const closeBtn = tooltip.querySelector(".tooltip-close");
   if (closeBtn) {
@@ -167,6 +171,7 @@ export async function initBatDataLayer(map, layersControl) {
       }
   
       lockedLayers.splice(idx, 1);
+      detachTooltipLine(tooltipElements[idx]);
       tooltipElements[idx].remove();
       tooltipElements.splice(idx, 1);
       manualMoved.splice(idx, 1);
@@ -401,6 +406,7 @@ export async function initBatDataLayer(map, layersControl) {
           if (lockedLayers.includes(marker)) {
             const idx = lockedLayers.indexOf(marker);
             lockedLayers.splice(idx, 1);
+            detachTooltipLine(tooltipElements[idx]);
             tooltipElements[idx].remove();
             tooltipElements.splice(idx, 1);
             manualMoved.splice(idx, 1);
@@ -480,6 +486,7 @@ export async function initBatDataLayer(map, layersControl) {
             if (lockedLayers.includes(layer)) {
               const idx = lockedLayers.indexOf(layer);
               lockedLayers.splice(idx, 1);
+              detachTooltipLine(tooltipElements[idx]);
               tooltipElements[idx].remove();
               tooltipElements.splice(idx, 1);
               manualMoved.splice(idx, 1);

--- a/js/batGrid.js
+++ b/js/batGrid.js
@@ -1,4 +1,5 @@
 import { makeTooltipDraggable } from './draggableTooltip.js';
+import { attachTooltipLine, detachTooltipLine, updateTooltipLine } from './tooltipLine.js';
 
 export function initBatGrid(map, layersControl) {
   const gridLayer = L.geoJSON(null);
@@ -100,6 +101,7 @@ export function initBatGrid(map, layersControl) {
       if (lockedLayers.includes(layer)) {
         const idx = lockedLayers.indexOf(layer);
         lockedLayers.splice(idx, 1);
+        detachTooltipLine(tooltipElements[idx]);
         tooltipElements[idx].remove();
         tooltipElements.splice(idx, 1);
         manualMoved.splice(idx, 1);
@@ -137,10 +139,15 @@ export function initBatGrid(map, layersControl) {
     tooltipElements.push(tooltip);
     manualMoved.push(false);
 
-    const center = map.latLngToContainerPoint(layer.getBounds().getCenter());
+    const targetLatLng = layer.getBounds().getCenter();
+    const center = map.latLngToContainerPoint(targetLatLng);
     positionTooltip(tooltip, center);
 
-    makeTooltipDraggable(tooltip);
+    makeTooltipDraggable(tooltip, {
+      onDrag: () => updateTooltipLine(tooltip),
+      onDragEnd: () => updateTooltipLine(tooltip)
+    });
+    attachTooltipLine(tooltip, targetLatLng);
   }
 
   function closeLockTooltip(event, closeButton) {
@@ -155,6 +162,7 @@ export function initBatGrid(map, layersControl) {
       const count = speciesData[gridNo] ? speciesData[gridNo].count : 0;
       layer.setStyle(getGridStyle(count));  // ✅ 還原樣式
       lockedLayers.splice(idx, 1);
+      detachTooltipLine(tooltipElements[idx]);
       tooltipElements[idx].remove();
       tooltipElements.splice(idx, 1);
       manualMoved.splice(idx, 1);

--- a/js/draggableTooltip.js
+++ b/js/draggableTooltip.js
@@ -1,4 +1,12 @@
-export function makeTooltipDraggable(tooltip, onDragEnd = null) {
+export function makeTooltipDraggable(tooltip, options = {}) {
+  let onDragEnd = null;
+  let onDrag = null;
+  if (typeof options === 'function') {
+    onDragEnd = options;
+  } else if (options) {
+    ({ onDragEnd = null, onDrag = null } = options);
+  }
+
   let isDragging = false;
   let offsetX, offsetY;
 
@@ -38,6 +46,7 @@ export function makeTooltipDraggable(tooltip, onDragEnd = null) {
 
     tooltip.style.left = `${clientX - offsetX}px`;
     tooltip.style.top = `${clientY - offsetY}px`;
+    if (typeof onDrag === 'function') onDrag();
   }
 
   function endDrag() {

--- a/js/drawPoints.js
+++ b/js/drawPoints.js
@@ -1,3 +1,5 @@
+import { attachTooltipLine, detachTooltipLine, updateTooltipLine, updateTooltipLineTarget } from './tooltipLine.js';
+
 export function initDrawPoint(map, crsModeSelect) {
   let drawMode = false;
   const drawnPoints = [];
@@ -68,6 +70,7 @@ export function initDrawPoint(map, crsModeSelect) {
         <div class="tooltip-content">${content}</div>
       </div>`;
     document.getElementById("map").appendChild(tooltip);
+    attachTooltipLine(tooltip, marker.getLatLng());
     return tooltip;
   }
 
@@ -109,6 +112,8 @@ export function initDrawPoint(map, crsModeSelect) {
 
     tooltip.style.left = `${left}px`;
     tooltip.style.top = `${top}px`;
+    updateTooltipLineTarget(tooltip, marker.getLatLng());
+    updateTooltipLine(tooltip);
   }
 
   map.on("move zoom", () => {
@@ -121,7 +126,10 @@ export function initDrawPoint(map, crsModeSelect) {
     const idx = drawnPoints.findIndex((m) => L.stamp(m) === markerId);
     if (idx !== -1) {
       map.removeLayer(drawnPoints[idx]);
-      if (drawnTooltips[markerId]) drawnTooltips[markerId].remove();
+      if (drawnTooltips[markerId]) {
+        detachTooltipLine(drawnTooltips[markerId]);
+        drawnTooltips[markerId].remove();
+      }
       drawnPoints.splice(idx, 1);
       delete drawnTooltips[markerId];
     }

--- a/js/goto.js
+++ b/js/goto.js
@@ -1,3 +1,5 @@
+import { attachTooltipLine, detachTooltipLine, updateTooltipLine, updateTooltipLineTarget } from './tooltipLine.js';
+
 export function initGotoPanel(map) {
   const panel = document.getElementById("gotoPanel");
   const toggleBtn = document.getElementById("gotoToggleBtn");
@@ -63,6 +65,7 @@ export function initGotoPanel(map) {
         const markerId = L.stamp(marker);
         const existing = gotoTooltips[markerId];
         if (existing) {
+          detachTooltipLine(existing);
           existing.remove();
           delete gotoTooltips[markerId];
         } else {
@@ -96,6 +99,7 @@ export function initGotoPanel(map) {
       map.removeLayer(m);
       const id = L.stamp(m);
       if (gotoTooltips[id]) {
+        detachTooltipLine(gotoTooltips[id]);
         gotoTooltips[id].remove();
         delete gotoTooltips[id];
       }
@@ -172,6 +176,7 @@ function createPointTooltip(marker, content) {
       <div class="tooltip-content">${content}</div>
     </div>`;
   document.getElementById("map").appendChild(tooltip);
+  attachTooltipLine(tooltip, marker.getLatLng());
   return tooltip;
 }
 
@@ -209,6 +214,8 @@ function moveGotoTooltip(marker) {
   if (top < 0) top = 10;
   tooltip.style.left = `${left}px`;
   tooltip.style.top = `${top}px`;
+  updateTooltipLineTarget(tooltip, latlng);
+  updateTooltipLine(tooltip);
 }
 
 window.deleteGotoMarker = function (event, markerId) {
@@ -216,11 +223,14 @@ window.deleteGotoMarker = function (event, markerId) {
   const idx = gotoMarkers.findIndex((m) => L.stamp(m) === markerId);
   if (idx !== -1) {
     map.removeLayer(gotoMarkers[idx]);
-    if (gotoTooltips[markerId]) gotoTooltips[markerId].remove();
+    if (gotoTooltips[markerId]) {
+      detachTooltipLine(gotoTooltips[markerId]);
+      gotoTooltips[markerId].remove();
+    }
     gotoMarkers.splice(idx, 1);
     delete gotoTooltips[markerId];
   }
-};  
+};
 
 function currentTooltipContent(marker) {
   const latlng = marker.getLatLng();

--- a/js/initMap.js
+++ b/js/initMap.js
@@ -46,6 +46,7 @@ export async function initMap() {
   
   // 建立各底圖圖層
   const streets = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", osmAttr).addTo(map);
+  window.currentBasemapName = "Street (OSM)";
   const esriSatellite = L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}", esriAttr);
   const cartoLight = L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", cartoAttr);
   const cartoDark = L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", cartoAttr);

--- a/js/tooltipLine.js
+++ b/js/tooltipLine.js
@@ -1,0 +1,64 @@
+export let mapInstance = null;
+const tooltipLineData = new Map(); // tooltipEl -> { line, targetLatLng }
+
+function getLineColor() {
+  const name = (window.currentBasemapName || '').toLowerCase();
+  return name.includes('satellite') || name.includes('hybrid') ? '#fff' : '#333';
+}
+
+export function initTooltipLine(map) {
+  mapInstance = map;
+  map.on('move zoom', updateAllTooltipLines);
+  map.on('baselayerchange', (e) => {
+    window.currentBasemapName = e.name || '';
+    updateAllTooltipLines();
+  });
+  window.currentBasemapName = window.currentBasemapName || 'Street';
+}
+
+export function attachTooltipLine(tooltipEl, targetLatLng) {
+  if (!mapInstance) return;
+  const svg = document.getElementById('tooltip-lines');
+  if (!svg) return;
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  line.classList.add('tooltip-line');
+  svg.appendChild(line);
+  tooltipLineData.set(tooltipEl, { line, targetLatLng });
+  updateTooltipLine(tooltipEl);
+}
+
+export function updateTooltipLineTarget(tooltipEl, targetLatLng) {
+  const data = tooltipLineData.get(tooltipEl);
+  if (data) {
+    data.targetLatLng = targetLatLng;
+  }
+}
+
+export function detachTooltipLine(tooltipEl) {
+  const data = tooltipLineData.get(tooltipEl);
+  if (data) {
+    data.line.remove();
+    tooltipLineData.delete(tooltipEl);
+  }
+}
+
+export function updateTooltipLine(tooltipEl) {
+  const data = tooltipLineData.get(tooltipEl);
+  if (!data || !mapInstance) return;
+  const { line, targetLatLng } = data;
+  const p1 = mapInstance.latLngToContainerPoint(targetLatLng);
+  const mapRect = document.getElementById('map').getBoundingClientRect();
+  const rect = tooltipEl.getBoundingClientRect();
+  const x2 = rect.left - mapRect.left + rect.width / 2;
+  const y2 = rect.top - mapRect.top + rect.height / 2;
+  line.setAttribute('x1', p1.x);
+  line.setAttribute('y1', p1.y);
+  line.setAttribute('x2', x2);
+  line.setAttribute('y2', y2);
+  line.setAttribute('stroke', getLineColor());
+  line.setAttribute('stroke-width', '2');
+}
+
+export function updateAllTooltipLines() {
+  tooltipLineData.forEach((_, tooltipEl) => updateTooltipLine(tooltipEl));
+}


### PR DESCRIPTION
## Summary
- create `tooltipLine` helper to draw a connector from tooltips to features
- support optional drag callbacks in `makeTooltipDraggable`
- connect floating tooltips in bat data, grid, draw point and goto modules
- keep connector lines synced with basemap color
- include SVG overlay and styles for connector lines

## Testing
- `ls js | grep tooltipLine`

------
https://chatgpt.com/codex/tasks/task_e_6889ae0a7a14832a94c28ed7702a9fd1