### PR TITLE
Fix click lock while dragging tooltip

### DIFF
--- a/js/clickLocationLock.js
+++ b/js/clickLocationLock.js
@@ -12,6 +12,7 @@ export function enableClickLock() {
 
 function isClickIgnored(el) {
   return (
+    el.closest(".floatingTooltip") ||
     el.closest("#coord-scale-wrapper") ||
     el.closest("#gotoPanel") ||
     el.closest("#clearBtn") ||
@@ -31,6 +32,7 @@ function isClickIgnored(el) {
 
 export function initClickLocationLock(map, coordDisplay, crsModeSelect) {
   map.on("click", (e) => {
+    if (window.isDraggingTooltip) return; // ⛔ 拖拉 Tooltip 時不鎖定
     const el = e.originalEvent.target;
     if (isClickIgnored(el)) return;
     

--- a/js/draggableTooltip.js
+++ b/js/draggableTooltip.js
@@ -15,6 +15,7 @@ export function makeTooltipDraggable(tooltip, options = {}) {
 
     isDragging = true;
     window.isDraggingAlphaStatus = true; // ✅ 拖動中：暫停 status 更新
+    window.isDraggingTooltip = true;      // ✅ 拖動中：避免觸發點擊鎖定
 
     if (e.type.startsWith('touch')) {
       const touch = e.touches[0];
@@ -53,6 +54,7 @@ export function makeTooltipDraggable(tooltip, options = {}) {
     if (isDragging) {
       isDragging = false;
       window.isDraggingAlphaStatus = false; // ✅ 拖動結束：允許更新
+      window.isDraggingTooltip = false;      // ✅ 拖動結束：恢復點擊鎖定
       tooltip.style.cursor = 'default';
       tooltip.style.transition = 'opacity 0.2s ease';
       tooltip.style.opacity = '1';


### PR DESCRIPTION
## Summary
- prevent click location lock from activating when dragging tooltips
- ignore clicks on floating tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889b37fc474832a93266c0dd4efa7a1