### PR TITLE
Fix marker order over grid

### DIFF
--- a/js/batData.js
+++ b/js/batData.js
@@ -361,6 +361,7 @@ export async function initBatDataLayer(map, layersControl) {
           return true;
         })
         .map(d => L.circleMarker([parseFloat(d.Latitude), parseFloat(d.Longitude)], {
+          pane: 'markerPane',
           radius: 5,
           fillColor: '#3388ff',
           color: '#3388ff',

--- a/js/initMap.js
+++ b/js/initMap.js
@@ -1,6 +1,10 @@
 // js/initMap.js
 export async function initMap() {
   const map = L.map("map");
+  map.createPane('hkgridPane');
+  const hkgridPane = map.getPane('hkgridPane');
+  hkgridPane.style.zIndex = 350;
+  hkgridPane.style.pointerEvents = 'none';
   const hongKongBounds = [
     [22.15, 113.825],
     [22.55, 114.4],
@@ -112,6 +116,8 @@ export async function initMap() {
     .then((r) => r.json())
     .then((hkgriddata) => {
       const hkgridLayer = L.geoJSON(hkgriddata, {
+        pane: 'hkgridPane',
+        interactive: false,
         style: {
           color: '#3388ff',
           weight: 2,


### PR DESCRIPTION
## Summary
- create a dedicated pane for the 1 km grid layer
- make the grid pane ignore pointer events so markers stay interactive
- keep markers in the marker pane above the grid

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_688b8c464240832a819c0aaf48940207